### PR TITLE
Add perfect match selection to anilist_app.go

### DIFF
--- a/anilist_app.go
+++ b/anilist_app.go
@@ -507,6 +507,10 @@ func alSelectEntry(ctx *cli.Context) error {
 	var matchedEntry *anilist.MediaListEntry = nil
 	for i, entry := range al.List {
 		title := entry.Title.Romaji + " " + entry.Title.English + " " + entry.Title.Native
+		if strings.ToLower(entry.Title.Romaji) == searchTerm {
+			matchedEntry = &al.List[i]
+			break
+		}
 		if strings.Contains(strings.ToLower(title), searchTerm) {
 			if matchedEntry != nil {
 				matchedEntry = nil

--- a/anilist_app.go
+++ b/anilist_app.go
@@ -507,7 +507,7 @@ func alSelectEntry(ctx *cli.Context) error {
 	var matchedEntry *anilist.MediaListEntry = nil
 	for i, entry := range al.List {
 		title := entry.Title.Romaji + " " + entry.Title.English + " " + entry.Title.Native
-		if strings.ToLower(entry.Title.Romaji) == searchTerm {
+		if strings.ToLower(entry.Title.UserPreferred) == searchTerm {
 			matchedEntry = &al.List[i]
 			break
 		}


### PR DESCRIPTION
# Description

If there is a perfect match on Romaji title, select the entry instead of showing multiple selections. 

Motivation: I was trying making a automation scripts and the GUI was opening even in cases when I pass the exact title of the anime.

# Old Behavior
command: `mal select uchuu kyoudai`

![image](https://user-images.githubusercontent.com/7642878/83963694-45e1e800-a87e-11ea-99c9-caff06adec3f.png)


# New Behavior
command: `mal select uchuu kyoudai` 

![image](https://user-images.githubusercontent.com/7642878/83963712-614cf300-a87e-11ea-859f-7a0c6fd0649c.png)

