### PR TITLE
replace data dir with XDG_CACHE

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ In order to have `mal copy` command working, you need to have either `xsel` or `
 
 ## Quick start
 
-If you have a working Go environment, you can download the app via `go get -u github.com/aqatl/mal`. 
+If you have a working Go environment, you can download the app via `go get -u github.com/aqatl/mal`.
 Otherwise, download binaries from the [release](https://github.com/aQaTL/MAL/releases) page.
 
-Remember that everything is stored in `$HOME/.mal` or `%userprofile%\.mal` (Windows).
+Remember that everything is stored in `$XDG_CACHE_HOME/mal` or `%LocalAppData%\mal` (Windows).
 
 ### AniList mode
 
-AniList mode is used by default. All you need to do to configure the app is to simply execute the program. 
-It'll open AniList login page in your browser. Log in and authorize the app. And that's it - mal will cache 
-the received token on your disk and use it to authenticate your requests. 
+AniList mode is used by default. All you need to do to configure the app is to simply execute the program.
+It'll open AniList login page in your browser. Log in and authorize the app. And that's it - mal will cache
+the received token on your disk and use it to authenticate your requests.
 
 Run mal with `-r` flag to refresh cached lists.
 
@@ -34,14 +34,14 @@ Run mal with `-r` flag to refresh cached lists.
 
 To switch between AniList and MyAnimeList mode use the `s` command (e.g. `mal s`).
 
-First, you need to give the app your credentials - username and password. To do that, execute 
-`mal --prompt-credentials --verify --save-password`. If everything went good, you should see 
+First, you need to give the app your credentials - username and password. To do that, execute
+`mal --prompt-credentials --verify --save-password`. If everything went good, you should see
 a list of 10 entries.
 
 ### Default behavior
 
-The base command for everything is `mal`, which by default displays 10 last updated entries 
-from your MAL. You can change the displayed list through some flags: 
+The base command for everything is `mal`, which by default displays 10 last updated entries
+from your MAL. You can change the displayed list through some flags:
 
 ```
 --max value                    visible entries threshold (default: 0)
@@ -53,7 +53,7 @@ from your MAL. You can change the displayed list through some flags:
 
 It's also good to run the app with `-r` (or `--refresh`) to update the cached list. Mind that there is not refresh interval so you have to refresh manually.
 
-List of all commands and possible flags is available via `mal --help`. 
+List of all commands and possible flags is available via `mal --help`.
 
 ### Commands
 
@@ -66,14 +66,14 @@ Commands listed in `help` are divides into categories:
 * **Action** command performs action that uses the entry data like printing it to the console
 * **Config** command manipulates on the app configuration file (look at `mal cfg --help` for details)
 
-You can always see the details of the specific command via `help` like this: 
+You can always see the details of the specific command via `help` like this:
 `mal <command> --help`
 
 #### Select entry to work with
 
-Commands that use entry data need to know which entry you want to use. And there's a thing 
-called "selected entry". To select an entry, use the `mal sel` command. And here's a usage 
-of that command (` mal sel --help`): 
+Commands that use entry data need to know which entry you want to use. And there's a thing
+called "selected entry". To select an entry, use the `mal sel` command. And here's a usage
+of that command (` mal sel --help`):
 
 ```
 NAME:
@@ -91,7 +91,7 @@ If `sel` is given no arguments, it will open a fuzzy search cui (console gui).
 
 #### Update entry
 
-For now, you can update your entry with the following commands: 
+For now, you can update your entry with the following commands:
 
 ```
 eps, episodes  Set the watched episodes value. If n not specified, the number will be increased by one
@@ -114,8 +114,8 @@ CATEGORY:
    Update
 ```
 
-There's an option to have mal automatically turn the entry status to completed after updating 
-the watched episodes value. To do that, use the `status-auto-update` config command. 
+There's an option to have mal automatically turn the entry status to completed after updating
+the watched episodes value. To do that, use the `status-auto-update` config command.
 
 ```
 NAME:
@@ -127,11 +127,11 @@ USAGE:
 
 As you can see, there are 2 modes of auto-update: normal and after-threshold.
 
-The first behaves as you would expect -> the status is changes when entry has 12 episodes 
+The first behaves as you would expect -> the status is changes when entry has 12 episodes
 and you hit the 12 watched episodes.
 
-As for the `after-threshold`, the status will change after you exceed the number of 
-episodes. For example: when entry has 12 episodes and you hit 13 -> status is changed to 
+As for the `after-threshold`, the status will change after you exceed the number of
+episodes. For example: when entry has 12 episodes and you hit 13 -> status is changed to
 completed and your watched entries value is changed back to 12.
 
 ##### `mal score` command
@@ -173,16 +173,16 @@ Remember that everything is in `--help` :)
 
 ### Everyday usage
 
-Okay, so when I add a new anime to my list, I run `mal -r` to update the cache. Then, if I 
-want to watch it, I select it with `mal sel [name]`. Then I go to the web browser to find a 
-website where I can watch it. If the name is long, I copy the title with `mal copy title`. 
-To not forget the website and make it a little bit more convenient for me in the future, I 
-copy the website's link and bind it to the selected anime with `mal web [website url]`. 
+Okay, so when I add a new anime to my list, I run `mal -r` to update the cache. Then, if I
+want to watch it, I select it with `mal sel [name]`. Then I go to the web browser to find a
+website where I can watch it. If the name is long, I copy the title with `mal copy title`.
+To not forget the website and make it a little bit more convenient for me in the future, I
+copy the website's link and bind it to the selected anime with `mal web [website url]`.
 
-Now, when I want to watch it, I can just type `mal web` and it will open saved url in the 
-web browser (you can configure which browser to use). When I finish an episode I type 
-`mal eps` to update watched episodes and that's it. There's an option to automatically set 
-the status to "completed", so I don't have to do anything more. 
+Now, when I want to watch it, I can just type `mal web` and it will open saved url in the
+web browser (you can configure which browser to use). When I finish an episode I type
+`mal eps` to update watched episodes and that's it. There's an option to automatically set
+the status to "completed", so I don't have to do anything more.
 
 Oh, and usually I also rate the show by `mal score [number from 0 to 10]`.
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 )
 
-var dataDir = filepath.Join(homeDir(), ".mal")
+var dataDir = getDataDir()
 var (
 	AppConfigFile = filepath.Join(dataDir, "appConfig.json")
 

--- a/utils.go
+++ b/utils.go
@@ -40,7 +40,7 @@ func getDataDir() string {
 	}
 
 	// Old dir isn't there, use new $XDG_CACHE_HOME/mal
-	dir, err := os.UserCacheDir()
+	dir, err := os.UserConfigDir()
 	if err != nil {
 		log.Printf("Error getting cache dir: %v", err)
 		return ""


### PR DESCRIPTION
Uses old $HOME/.mal data dir when available but automatically switches to $XDG_CACHE_HOME/mal whenever possible. Updates readme to reflect these changes

I opted for $XDG_CACHE_HOME over $XDG_DATA_HOME due to go's OS package support for it, and support on windows and mac.

I was able to compile this with the build script without errors, and the functionality worked on my 64 bit Linux system.

This should fix #4 